### PR TITLE
Add trading scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # KBTCH
 Kalshi BTC hourly
+
+## Trading Scripts
+
+- `trading_bot.py` runs the live trader using the production Kalshi API. It relies on
+  environment variables `KALSHI_API_KEY` and `KALSHI_PRIVATE_KEY_PATH` to sign requests.
+- `demo_trading_bot.py` is identical but uses Kalshi's demo environment. Both scripts
+  leverage `kalshirunner.py` for market data and signal generation.
+
+The trading REST client is implemented in `kalshi_bot/kalshi_trade_api.py`.
+

--- a/demo_trading_bot.py
+++ b/demo_trading_bot.py
@@ -1,0 +1,12 @@
+from trading_bot import LiveTrader
+import asyncio
+
+
+def main():
+    trader = LiveTrader(use_demo=True)
+    asyncio.run(trader.run_trading_loop())
+
+
+if __name__ == "__main__":
+    main()
+

--- a/kalshi_bot/kalshi_trade_api.py
+++ b/kalshi_bot/kalshi_trade_api.py
@@ -1,0 +1,89 @@
+import os
+import base64
+import time
+import json
+from typing import Optional, Dict, Any
+from pathlib import Path
+
+import requests
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.backends import default_backend
+
+
+class KalshiTradeAPI:
+    """Minimal Kalshi Trade API client for executing orders."""
+
+    def __init__(self, use_demo: bool = False):
+        self.key_id = os.getenv("KALSHI_API_KEY")
+        self.private_key_path = os.getenv("KALSHI_PRIVATE_KEY_PATH")
+
+        if not self.key_id or not self.private_key_path:
+            raise ValueError(
+                "KALSHI_API_KEY and KALSHI_PRIVATE_KEY_PATH environment variables are required"
+            )
+
+        self.private_key = self._load_private_key()
+        if use_demo:
+            self.base_url = "https://demo-api.kalshi.co/trade-api/v2"
+        else:
+            self.base_url = "https://api.elections.kalshi.com/trade-api/v2"
+
+    def _load_private_key(self):
+        key_path = Path(self.private_key_path)
+        if not key_path.exists():
+            raise FileNotFoundError(f"Private key not found: {self.private_key_path}")
+        with open(key_path, "rb") as f:
+            return serialization.load_pem_private_key(f.read(), password=None, backend=default_backend())
+
+    def _sign(self, timestamp: str, method: str, path: str) -> str:
+        message = f"{timestamp}{method}{path}".encode()
+        signature = self.private_key.sign(
+            message,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+        return base64.b64encode(signature).decode()
+
+    def _headers(self, method: str, path: str) -> Dict[str, str]:
+        timestamp = str(int(time.time() * 1000))
+        signature = self._sign(timestamp, method, path)
+        return {
+            "KALSHI-ACCESS-KEY": self.key_id,
+            "KALSHI-ACCESS-TIMESTAMP": timestamp,
+            "KALSHI-ACCESS-SIGNATURE": signature,
+            "Content-Type": "application/json",
+        }
+
+    def _request(self, method: str, path: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        url = self.base_url + path
+        headers = self._headers(method, path)
+        if method == "GET":
+            response = requests.get(url, headers=headers, params=data)
+        elif method == "POST":
+            response = requests.post(url, headers=headers, json=data)
+        elif method == "DELETE":
+            response = requests.delete(url, headers=headers, json=data)
+        else:
+            raise ValueError("Unsupported HTTP method")
+
+        response.raise_for_status()
+        if not response.text:
+            return {}
+        return response.json()
+
+    def get_balance(self) -> Dict[str, Any]:
+        return self._request("GET", "/balance")
+
+    def create_order(self, market_ticker: str, side: str, quantity: int, price: float) -> Dict[str, Any]:
+        data = {
+            "type": "limit",
+            "side": side,
+            "market_ticker": market_ticker,
+            "size": quantity,
+            "price": price,
+        }
+        return self._request("POST", "/orders", data)
+
+    def cancel_order(self, order_id: str) -> Dict[str, Any]:
+        return self._request("DELETE", f"/orders/{order_id}")

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1,0 +1,83 @@
+import asyncio
+import time
+from typing import Dict
+
+from kalshirunner import VolatilityAdaptiveTrader
+from kalshi_bot.kalshi_trade_api import KalshiTradeAPI
+
+
+class LiveTrader(VolatilityAdaptiveTrader):
+    """VolatilityAdaptiveTrader with trade execution using Kalshi REST API."""
+
+    def __init__(self, event_id: str = None, use_demo: bool = False, order_size: int = 1):
+        super().__init__(event_id)
+        self.api = KalshiTradeAPI(use_demo=use_demo)
+        self.order_size = order_size
+        self.last_trade: Dict[str, float] = {}
+
+    def _should_trade(self, ticker: str) -> bool:
+        last = self.last_trade.get(ticker, 0)
+        return time.time() - last > 30
+
+    def _mark_traded(self, ticker: str):
+        self.last_trade[ticker] = time.time()
+
+    async def run_trading_loop(self):
+        if not await self.initialize():
+            return
+
+        try:
+            while not self.shutdown_requested:
+                if not self.brti_manager.is_brti_running():
+                    await self.brti_manager.start_brti()
+
+                current_btc = self.btc_monitor.get_current_price()
+                if current_btc and current_btc != self.last_btc_price:
+                    self.last_btc_price = current_btc
+                    self.btc_updates += 1
+
+                new_volatility = self.btc_monitor.calculate_volatility()
+                if abs(new_volatility - self.current_volatility) > 0.1:
+                    self.current_volatility = new_volatility
+                    self.volatility_updates += 1
+                    await self._update_market_subscriptions()
+
+                for market in self.active_markets:
+                    market.market_data = self.client.get_mid_prices(market.ticker)
+                    if market.market_data:
+                        market = self.analyzer.analyze_market_opportunity(
+                            market, self.last_btc_price, self.current_volatility
+                        )
+                        if market.action in ["BUY_YES", "SELL_YES"] and self._should_trade(market.ticker):
+                            side = "buy" if market.action == "BUY_YES" else "sell"
+                            price = market.market_data.yes_ask if side == "buy" else market.market_data.yes_bid
+                            try:
+                                resp = self.api.create_order(
+                                    market.ticker, side, self.order_size, price
+                                )
+                                print(f"Placed {side} order on {market.ticker} @ {price}: {resp.get('status','ok')}")
+                                self._mark_traded(market.ticker)
+                            except Exception as e:
+                                print(f"Order failed: {e}")
+
+                lines = self.display.format_market_display(
+                    self.active_markets, self.last_btc_price,
+                    self.current_volatility, self.brti_manager.is_brti_running()
+                )
+                self.display.update_multiline_display(lines)
+
+                await asyncio.sleep(0.5)
+        except KeyboardInterrupt:
+            self.display.print_new_line("\n🛑 Shutting down...")
+        finally:
+            await self._cleanup()
+
+
+def main():
+    trader = LiveTrader()
+    asyncio.run(trader.run_trading_loop())
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- implement Kalshi REST API client
- add trading bot using kalshirunner data for order logic
- provide demo trading entrypoint
- document scripts in README

## Testing
- `python -m py_compile kalshi_bot/kalshi_trade_api.py trading_bot.py demo_trading_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_686f0445e0d883208c10db2af9373e4c